### PR TITLE
Containing the pull server start up using doxygen

### DIFF
--- a/scripts/pull_server/CMakeLists.patch
+++ b/scripts/pull_server/CMakeLists.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a6766ad..d9ea96e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+ project( hexactrl )
+ 
+ include(CheckCXXCompilerFlag)
+-check_cxx_compiler_flag(-std=c++14 HAVE_FLAG_STD_CXX14)
+-if(HAVE_FLAG_STD_CXX14)
+-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" )
+-  message("will use c++14")
++check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
++if(HAVE_FLAG_STD_CXX17)
++  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17" )
++  message("will use c++17")
+ else()
+   check_cxx_compiler_flag(-std=c++11 HAVE_FLAG_STD_CXX11)
+   if(HAVE_FLAG_STD_CXX11)
+@@ -117,7 +117,7 @@ else()
+     message( "\t${exec}" )
+     get_filename_component(ex ${exec} NAME_WE)
+     add_executable( ${ex} ${exec} $<TARGET_OBJECTS:anaobjectlib> ${headers} )
+-    target_link_libraries( ${ex} ${Boost_LIBRARIES} boost_program_options boost_regex boost_serialization boost_chrono )
++    target_link_libraries( ${ex} ${Boost_LIBRARIES} boost_program_options boost_regex boost_serialization boost_chrono zmq yaml-cpp)
+     install( TARGETS ${ex} DESTINATION ${DESTINATION}/bin
+       ARCHIVE DESTINATION ${DESTINATION}/lib
+       LIBRARY DESTINATION ${DESTINATION}/lib )

--- a/scripts/pull_server/data_puller.dockerfile
+++ b/scripts/pull_server/data_puller.dockerfile
@@ -13,11 +13,12 @@ RUN apt update; \
     apt-get -y install ${MAKE_DEPS} ${PKGS_DEPS} ${ROOT_DEPS} ${PYTHON_DEPS}
 
 
-# Installing ROOT
+# Installing ROOT (as per official root instructions)
 RUN wget https://root.cern/download/root_v6.28.04.Linux-ubuntu22-x86_64-gcc11.3.tar.gz; \
     tar -xzf root_v6.28.04.Linux-ubuntu22-x86_64-gcc11.3.tar.gz;                        \
     source root/bin/thisroot.sh
 ENV ROOTSYS=/srv/root
+
 ## Compiling the client code (Not using git clone here, as hexactrl is in a private repository)
 COPY ./ /srv/hexactrl-sw
 
@@ -27,4 +28,6 @@ RUN mkdir -p hexactrl-sw/build;                                                 
     cmake -DBUILD_CLIENT=ON ../ ; make; make install;                                 \
     patch -u -i ../requirements.patch /srv/hexactrl/hexactrl-script/requirements.txt; \
     python3 -m pip install --break-system-packages -r /srv/hexactrl-sw/hexactrl-script/requirements.txt
+# Additional python paths to use
+ENV PYTHONPATH=$PYTHONPATH:/srv/hexactrl-sw/hexactrl-script/analysis
 

--- a/scripts/pull_server/data_puller.dockerfile
+++ b/scripts/pull_server/data_puller.dockerfile
@@ -1,0 +1,30 @@
+# Primary base image setup
+FROM    ubuntu:23.04
+WORKDIR /srv
+SHELL ["/bin/bash", "-c"]
+
+# Required packages
+ARG MAKE_DEPS="cmake git g++ gcc wget"
+ARG PKGS_DEPS="libboost-all-dev libyaml-cpp-dev python3 libpugixml-dev libbsd-dev pkg-config cppzmq-dev libzmq3-dev systemd"
+ARG ROOT_DEPS="dpkg-dev binutils libx11-dev libxpm-dev libgnutls28-dev"
+ARG PYTHON_DEPS="python3-pip python3-numpy liblapack3 libjpeg-dev zlib1g-dev"
+# Standard update and official packages
+RUN apt update; \
+    apt-get -y install ${MAKE_DEPS} ${PKGS_DEPS} ${ROOT_DEPS} ${PYTHON_DEPS}
+
+
+# Installing ROOT
+RUN wget https://root.cern/download/root_v6.28.04.Linux-ubuntu22-x86_64-gcc11.3.tar.gz; \
+    tar -xzf root_v6.28.04.Linux-ubuntu22-x86_64-gcc11.3.tar.gz;                        \
+    source root/bin/thisroot.sh
+ENV ROOTSYS=/srv/root
+## Compiling the client code (Not using git clone here, as hexactrl is in a private repository)
+COPY ./ /srv/hexactrl-sw
+
+RUN mkdir -p hexactrl-sw/build;                                                       \
+    cd hexactrl-sw/build ;                                                            \
+    patch -u -i ../CMakeLists.patch ../CMakeLists.txt;                                \
+    cmake -DBUILD_CLIENT=ON ../ ; make; make install;                                 \
+    patch -u -i ../requirements.patch /srv/hexactrl/hexactrl-script/requirements.txt; \
+    python3 -m pip install --break-system-packages -r /srv/hexactrl-sw/hexactrl-script/requirements.txt
+

--- a/scripts/pull_server/fetch_files.sh
+++ b/scripts/pull_server/fetch_files.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Cloning the required repository
+git clone ssh://git@gitlab.cern.ch:7999/hgcal-daq-sw/hexactrl-sw.git       -b ROCv3
+git clone ssh://git@gitlab.cern.ch:7999/hgcal-daq-sw/hexactrl-script.git   -b ROCv3_Tileboardv2p1 hexactrl-sw/hexasctrl-script
+git clone ssh://git@gitlab.cern.ch:7999/hgcal-daq-sw/hexactrl-analysis.git -b ROCv3               hexactrl-sw/hexactrl-script/analysis
+
+# Pulling the docker file and patching requirements
+wget https://raw.githubusercontent.com/UMDCMS/SiPMCalibControl/master/scripts/pull_server/data_puller.dockerfile
+wget https://raw.githubusercontent.com/UMDCMS/SiPMCalibControl/master/scripts/pull_server/CMakeLists.patch
+wget https://raw.githubusercontent.com/UMDCMS/SiPMCalibControl/master/scripts/pull_server/run_docker.sh
+chmod +x run_docker.sh

--- a/scripts/pull_server/fetch_files.sh
+++ b/scripts/pull_server/fetch_files.sh
@@ -6,6 +6,7 @@ git clone ssh://git@gitlab.cern.ch:7999/hgcal-daq-sw/hexactrl-script.git   -b RO
 git clone ssh://git@gitlab.cern.ch:7999/hgcal-daq-sw/hexactrl-analysis.git -b ROCv3               hexactrl-sw/hexactrl-script/analysis
 
 # Pulling the docker file and patching requirements
+cd hexactrl-sw
 wget https://raw.githubusercontent.com/UMDCMS/SiPMCalibControl/master/scripts/pull_server/data_puller.dockerfile
 wget https://raw.githubusercontent.com/UMDCMS/SiPMCalibControl/master/scripts/pull_server/CMakeLists.patch
 wget https://raw.githubusercontent.com/UMDCMS/SiPMCalibControl/master/scripts/pull_server/run_docker.sh

--- a/scripts/pull_server/requirements.patch
+++ b/scripts/pull_server/requirements.patch
@@ -1,0 +1,28 @@
+diff --git a/requirements.txt b/requirements.txt
+index f4116e3..8c42dc4 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -2,10 +2,10 @@ awkward0==0.15.5
+ cachetools==4.2.4
+ cycler==0.11.0
+ kiwisolver==1.3.1
+-matplotlib==3.3.4
+-nested-dict==1.61
+-numpy==1.19.5
+-pandas==1.1.5
++matplotlib
++nested-dict
++numpy
++pandas
+ Pillow==8.4.0
+ pyinotify==0.9.6
+ pyparsing==3.0.9
+@@ -13,7 +13,7 @@ python-dateutil==2.8.2
+ pytz==2022.1
+ PyYAML==6.0
+ pyzmq==23.2.0
+-scipy==1.5.4
++scipy
+ six==1.16.0
+ uproot3==3.14.4
+ uproot3-methods==0.10.1

--- a/scripts/pull_server/requirements.patch
+++ b/scripts/pull_server/requirements.patch
@@ -11,6 +11,7 @@ index f4116e3..8c42dc4 100644
 -numpy==1.19.5
 -pandas==1.1.5
 +matplotlib
++seaborn
 +nested-dict
 +numpy
 +pandas

--- a/scripts/pull_server/run_docker.sh
+++ b/scripts/pull_server/run_docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker buildx build  --network="host" --tag hexactrl-client --rm --load -f data_puller.dockerfile ./
+docker run -it       --network="host" hexactrl-client:latest  /bin/bash $EXEC


### PR DESCRIPTION
Since the data puller server is now required to be run on a separate machine from the tileboard tester, here we contain the data puller instance in a doxygen instance to ensure it can always run regardless of machine setup.

- [ ] Update README and documentations of how to use the scripts
- [ ] Allow a standalone data puller that runs nothing in the background.